### PR TITLE
Fix polly mc path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Patch
+The original code uses a hardcoded link for PollyMC, which has broken.
+
+I have updated the code to pull the latest release of PollyMC, though compatibility
+may break with future updates.
+
+The hardcoded branch uses a fixed PollyMC version, from the main PollyMC github,
+which should exist for a while.
+
 # Minecraft Splitscreen Steam Deck & Linux Installer
 
 This project provides an easy way to set up splitscreen Minecraft on Steam Deck and Linux using an optimized dual-launcher approach. It supports 1–4 players, controller detection, and seamless integration with Steam Game Mode and your desktop environment.
@@ -91,7 +100,7 @@ This hybrid approach ensures reliable automated installation while providing the
    chmod +x install-minecraft-splitscreen.sh
    ./install-minecraft-splitscreen.sh
    ```
-   
+
    **Note:** The installer will automatically detect which Java version you need based on your selected Minecraft version and install it if not present. No manual Java setup required!
 
 2. **Install Python 3 (optional)**
@@ -115,7 +124,7 @@ This hybrid approach ensures reliable automated installation while providing the
      - Handle mod conflicts and suggest alternatives when needed
      - Show progress for each mod download with success/failure status
      - Report any missing mods at the end if compatible versions aren't found
-   - **Steam integration (optional):** 
+   - **Steam integration (optional):**
      - Choose "y" to add a shortcut to Steam for easy access from Game Mode on Steam Deck
      - Choose "n" if you prefer to launch manually or don't use Steam
    - **Desktop launcher (optional):**

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Patch
-The original code uses a hardcoded link for PollyMC, which has broken.
+The original code uses a hardcoded link for PollyMC, which has gone down.
 
 I have updated the code to pull the latest release of PollyMC, though compatibility
 may break with future updates.
 
-The hardcoded branch uses a fixed PollyMC version, from the main PollyMC github,
+The locked-version branch uses a fixed PollyMC link, from the main PollyMC github,
 which should exist for a while.
 
 # Minecraft Splitscreen Steam Deck & Linux Installer

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ may break with future updates.
 The locked-version branch uses a fixed PollyMC link, from the main PollyMC github,
 which should exist for a while.
 
+I don't think the releases compiled here so use the wget commit below to
+download the installer.
+
+```sh
+wget https://raw.githubusercontent.com/asagilmore/MinecraftSplitscreenSteamdeck/main/install-minecraft-splitscreen.sh
+chmod +x install-minecraft-splitscreen.sh
+./install-minecraft-splitscreen.sh
+```
+
 # Minecraft Splitscreen Steam Deck & Linux Installer
 
 This project provides an easy way to set up splitscreen Minecraft on Steam Deck and Linux using an optimized dual-launcher approach. It supports 1–4 players, controller detection, and seamless integration with Steam Game Mode and your desktop environment.
@@ -96,7 +105,7 @@ This hybrid approach ensures reliable automated installation while providing the
 1. **Download and run the installer:**
    - You can get the latest installer script from the [Releases section](https://github.com/FlyingEwok/MinecraftSplitscreenSteamdeck/releases) (recommended for stable versions), or use the latest development version with:
    ```sh
-   wget https://raw.githubusercontent.com/FlyingEwok/MinecraftSplitscreenSteamdeck/main/install-minecraft-splitscreen.sh
+   wget https://raw.githubusercontent.com/asagilmore/MinecraftSplitscreenSteamdeck/main/install-minecraft-splitscreen.sh
    chmod +x install-minecraft-splitscreen.sh
    ./install-minecraft-splitscreen.sh
    ```

--- a/install-minecraft-splitscreen.sh
+++ b/install-minecraft-splitscreen.sh
@@ -2,7 +2,7 @@
 # =============================================================================
 # Minecraft Splitscreen Steam Deck Installer - MODULAR VERSION
 # =============================================================================
-# 
+#
 # This is the new, clean modular entry point for the Minecraft Splitscreen installer.
 # All functionality has been moved to organized modules for better maintainability.
 # Required modules are automatically downloaded as temporary files when the script runs.
@@ -52,7 +52,7 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODULES_DIR="$(mktemp -d -t minecraft-modules-XXXXXX)"
 
 # GitHub repository information (modify these URLs to match your actual repository)
-readonly REPO_BASE_URL="https://raw.githubusercontent.com/FlyingEwok/MinecraftSplitscreenSteamdeck/main/modules"
+readonly REPO_BASE_URL="https://raw.githubusercontent.com/asagilmore/MinecraftSplitscreenSteamdeck/main/modules"
 
 # List of required module files
 readonly MODULE_FILES=(
@@ -74,22 +74,22 @@ download_modules() {
     echo "🔄 Downloading required modules to temporary directory..."
     echo "📁 Temporary modules directory: $MODULES_DIR"
     echo "🌐 Repository URL: $REPO_BASE_URL"
-    
+
     # Temporarily disable strict error handling for downloads
     set +e
-    
+
     # The temporary directory is already created by mktemp
     local downloaded_count=0
     local failed_count=0
-    
+
     # Download each required module
     for module in "${MODULE_FILES[@]}"; do
         local module_path="$MODULES_DIR/$module"
         local module_url="$REPO_BASE_URL/$module"
-        
+
         echo "⬇️  Downloading module: $module"
         echo "    URL: $module_url"
-        
+
         # Download the module file
         if command -v curl >/dev/null 2>&1; then
             curl_output=$(curl -fsSL "$module_url" -o "$module_path" 2>&1)
@@ -126,10 +126,10 @@ download_modules() {
             exit 1
         fi
     done
-    
+
     # Re-enable strict error handling
     set -euo pipefail
-    
+
     if [[ $failed_count -gt 0 ]]; then
         echo "❌ Failed to download $failed_count module(s)"
         echo "ℹ️  This might be because:"
@@ -141,10 +141,10 @@ download_modules() {
         echo "    mkdir -p '$SCRIPT_DIR/modules'"
         echo "    # Then copy all .sh module files to that directory"
         echo ""
-        echo "🌐 Or check if the repository exists at: https://github.com/FlyingEwok/MinecraftSplitscreenSteamdeck"
+        echo "🌐 Or check if the repository exists at: https://github.com/asagilmore/MinecraftSplitscreenSteamdeck"
         exit 1
     fi
-    
+
     echo "✅ Downloaded $downloaded_count module(s) to temporary directory"
     echo "ℹ️  Modules will be automatically cleaned up when script completes"
 }

--- a/minecraftSplitscreen.sh
+++ b/minecraftSplitscreen.sh
@@ -37,7 +37,7 @@ detectLauncher() {
         export LAUNCHER_NAME="PollyMC"
         return 0
     fi
-    
+
     echo "[Error] PollyMC not found at $HOME/.local/share/PollyMC/" >&2
     echo "[Error] Please run the Minecraft Splitscreen installer to set up PollyMC" >&2
     return 1
@@ -56,7 +56,7 @@ echo "[Info] Using $LAUNCHER_NAME for splitscreen gameplay"
 # =============================
 # Checks if this script is the latest version from GitHub. If not, downloads and replaces itself.
 selfUpdate() {
-    local repo_url="https://raw.githubusercontent.com/FlyingEwok/MinecraftSplitscreenSteamdeck/main/minecraftSplitscreen.sh"
+    local repo_url="https://raw.githubusercontent.com/asagilmore/MinecraftSplitscreenSteamdeck/main/minecraftSplitscreen.sh"
     local tmpfile
     tmpfile=$(mktemp)
     local script_path

--- a/modules/pollymc_setup.sh
+++ b/modules/pollymc_setup.sh
@@ -2,7 +2,7 @@
 # =============================================================================
 # Minecraft Splitscreen Steam Deck Installer - PollyMC Setup Module
 # =============================================================================
-# 
+#
 # This module handles the setup and optimization of PollyMC as the primary
 # launcher for splitscreen gameplay, providing better offline support and
 # handling of multiple simultaneous instances compared to PrismLauncher.
@@ -15,13 +15,13 @@
 # =============================================================================
 
 # setup_pollymc: Configure PollyMC as the primary launcher for splitscreen gameplay
-# 
+#
 # POLLYMC ADVANTAGES FOR SPLITSCREEN:
 # - No forced Microsoft login requirements (offline-friendly)
 # - Better handling of multiple simultaneous instances
 # - Cleaner interface without authentication popups
 # - More stable for automated controller-based launching
-# 
+#
 # PROCESS OVERVIEW:
 # 1. Download PollyMC AppImage from GitHub releases
 # 2. Migrate all instances from PrismLauncher to PollyMC
@@ -35,29 +35,33 @@
 # This ensures the installation completes successfully regardless
 setup_pollymc() {
     print_header "🎮 SETTING UP POLLYMC"
-    
+
     print_progress "Downloading PollyMC for optimized splitscreen gameplay..."
-    
+
     # =============================================================================
     # POLLYMC DIRECTORY INITIALIZATION
     # =============================================================================
-    
+
     # Create PollyMC data directory structure
     # PollyMC stores instances, accounts, configuration, and launcher script here
     # Structure: ~/.local/share/PollyMC/{instances/, accounts.json, PollyMC AppImage}
     mkdir -p "$HOME/.local/share/PollyMC"
-    
+
     # =============================================================================
     # POLLYMC APPIMAGE DOWNLOAD AND VERIFICATION
     # =============================================================================
-    
+
     # Download PollyMC AppImage from official GitHub releases
     # AppImage format provides universal Linux compatibility without dependencies
     # PollyMC GitHub releases API endpoint for latest version
     # We download the x86_64 Linux AppImage which works on most modern Linux systems
-    local pollymc_url="https://github.com/fn2006/PollyMC/releases/latest/download/PollyMC-Linux-x86_64.AppImage"
+    local pollymc_url="$(
+    curl -s https://api.github.com/repos/PolyMC/PolyMC/releases/latest |
+        jq -r '.assets[] | select(.name | test("PolyMC-Linux-.*-x86_64.AppImage$")) | .browser_download_url'
+    )"
+
     print_progress "Fetching PollyMC from GitHub releases: $(basename "$pollymc_url")..."
-    
+
     # DOWNLOAD WITH FALLBACK HANDLING
     # If PollyMC download fails, we continue with PrismLauncher as the primary launcher
     # This ensures installation doesn't fail completely due to network issues or GitHub downtime
@@ -77,12 +81,12 @@ setup_pollymc() {
     # =============================================================================
     # INSTANCE MIGRATION: Transfer all Minecraft instances from PrismLauncher
     # =============================================================================
-    
+
     # INSTANCE DIRECTORY MIGRATION
     # Copy the complete instances directory structure from PrismLauncher to PollyMC
     # This includes all 4 splitscreen instances with their configurations, mods, and saves
     print_progress "Migrating PrismLauncher instances to PollyMC data directory..."
-    
+
     # INSTANCES TRANSFER: Copy entire instances folder with all splitscreen configurations
     # Each instance (latestUpdate-1 through latestUpdate-4) contains:
     # - Minecraft version configuration
@@ -93,7 +97,7 @@ setup_pollymc() {
     if [[ -d "$TARGET_DIR/instances" ]]; then
         cp -r "$TARGET_DIR/instances" "$HOME/.local/share/PollyMC/"
         print_success "✅ Splitscreen instances migrated to PollyMC"
-        
+
         # INSTANCE COUNT VERIFICATION: Ensure all 4 instances were copied successfully
         local instance_count
         instance_count=$(find "$HOME/.local/share/PollyMC/instances" -maxdepth 1 -name "latestUpdate-*" -type d 2>/dev/null | wc -l)
@@ -101,11 +105,11 @@ setup_pollymc() {
     else
         print_warning "⚠️  No instances directory found in PrismLauncher - this shouldn't happen"
     fi
-    
+
     # =============================================================================
     # ACCOUNT CONFIGURATION MIGRATION
     # =============================================================================
-    
+
     # OFFLINE ACCOUNTS TRANSFER: Copy splitscreen player account configurations
     # The accounts.json file contains offline player profiles for Player 1-4
     # These accounts allow splitscreen gameplay without requiring multiple Microsoft accounts
@@ -120,12 +124,12 @@ setup_pollymc() {
     # =============================================================================
     # POLLYMC CONFIGURATION: Skip Setup Wizard
     # =============================================================================
-    
+
     # SETUP WIZARD BYPASS: Create PollyMC configuration using user's proven working settings
     # This uses the exact configuration from the user's working PollyMC installation
     # Guarantees compatibility and skips all setup wizard prompts
     print_progress "Configuring PollyMC with proven working settings..."
-    
+
     # Get the current hostname for dynamic configuration with multiple fallback methods
     local current_hostname
     if command -v hostname >/dev/null 2>&1; then
@@ -137,7 +141,7 @@ setup_pollymc() {
     else
         current_hostname="localhost"
     fi
-    
+
     cat > "$HOME/.local/share/PollyMC/pollymc.cfg" <<EOF
 [General]
 ApplicationTheme=system
@@ -155,7 +159,7 @@ MinMemAlloc=512
 ToolbarsLocked=false
 WideBarVisibility_instanceToolBar="@ByteArray(111111111,BpBQWIumr+0ABXFEarV0R5nU0iY=)"
 EOF
-    
+
     print_success "✅ PollyMC configured to skip setup wizard"
     print_info "   → Setup wizard will not appear on first launch"
     print_info "   → Java path and memory settings pre-configured"
@@ -163,42 +167,42 @@ EOF
     # =============================================================================
     # POLLYMC COMPATIBILITY VERIFICATION
     # =============================================================================
-    
+
     # POLLYMC FUNCTIONALITY TEST: Verify PollyMC works on this system
     # Test basic AppImage execution and CLI functionality before committing to use PollyMC
     # Some older systems or restricted environments may have issues with AppImages
     print_progress "Testing PollyMC compatibility and basic functionality..."
-    
+
     # APPIMAGE EXECUTION TEST: Run PollyMC with --help flag to verify it works
     # Timeout prevents hanging if AppImage has issues
     # This tests: AppImage execution, basic CLI functionality, system compatibility
     if timeout 5s "$HOME/.local/share/PollyMC/PollyMC-Linux-x86_64.AppImage" --help >/dev/null 2>&1; then
         print_success "✅ PollyMC compatibility test passed - AppImage executes properly"
-        
+
         # =============================================================================
         # POLLYMC INSTANCE VERIFICATION AND FINAL SETUP
         # =============================================================================
-        
+
         # INSTANCE ACCESS VERIFICATION: Confirm PollyMC can detect and access migrated instances
         # This ensures PollyMC properly recognizes the instance format from PrismLauncher
         # Both launchers use similar formats, but compatibility should be verified
         print_progress "Verifying PollyMC can access migrated splitscreen instances..."
         local polly_instances_count
         polly_instances_count=$(find "$HOME/.local/share/PollyMC/instances" -maxdepth 1 -name "latestUpdate-*" -type d 2>/dev/null | wc -l)
-        
+
         if [[ "$polly_instances_count" -eq 4 ]]; then
             print_success "✅ PollyMC instance verification successful - all 4 instances accessible"
             print_info "   → latestUpdate-1, latestUpdate-2, latestUpdate-3, latestUpdate-4 ready"
-            
+
             # LAUNCHER SCRIPT CONFIGURATION: Set up the splitscreen launcher for PollyMC
             # This configures the controller detection and multi-instance launch script
             setup_pollymc_launcher
-            
+
             # CLEANUP PHASE: Remove PrismLauncher since PollyMC is working
             # This saves significant disk space (~500MB+) and avoids launcher confusion
             # PrismLauncher was only needed for the CLI-based instance creation process
             cleanup_prism_launcher
-            
+
             print_success "🎮 PollyMC is now the primary launcher for splitscreen gameplay"
             print_info "   → PrismLauncher files cleaned up to save disk space"
         else
@@ -218,13 +222,13 @@ EOF
 # Downloads and modifies the launcher script to use PollyMC instead of PrismLauncher
 setup_pollymc_launcher() {
     print_progress "Setting up launcher script for PollyMC..."
-    
+
     # LAUNCHER SCRIPT DOWNLOAD: Get the splitscreen launcher script from GitHub
     # This script handles controller detection and multi-instance launching
     if wget -O "$HOME/.local/share/PollyMC/minecraftSplitscreen.sh" \
         "https://raw.githubusercontent.com/FlyingEwok/MinecraftSplitscreenSteamdeck/main/minecraftSplitscreen.sh"; then
         chmod +x "$HOME/.local/share/PollyMC/minecraftSplitscreen.sh"
-        
+
         # LAUNCHER SCRIPT CONFIGURATION: Modify paths to use PollyMC instead of PrismLauncher
         # Replace PrismLauncher AppImage path with PollyMC AppImage path
         sed -i 's|PrismLauncher/PrismLauncher.AppImage|PollyMC/PollyMC-Linux-x86_64.AppImage|g' \
@@ -232,7 +236,7 @@ setup_pollymc_launcher() {
         # Replace PrismLauncher data directory with PollyMC data directory
         sed -i 's|/.local/share/PrismLauncher/|/.local/share/PollyMC/|g' \
             "$HOME/.local/share/PollyMC/minecraftSplitscreen.sh"
-        
+
         print_success "Launcher script configured and copied to PollyMC"
     else
         print_warning "Failed to download launcher script"
@@ -244,11 +248,11 @@ setup_pollymc_launcher() {
 # PrismLauncher was only needed for automated instance creation via CLI
 cleanup_prism_launcher() {
     print_progress "Cleaning up PrismLauncher (no longer needed)..."
-    
+
     # SAFETY: Navigate to home directory before removal operations
     # This prevents accidental deletion if we're currently in the target directory
     cd "$HOME" || return 1
-    
+
     # SAFETY CHECKS: Multiple validations before removing directories
     # Ensure we're not deleting critical system directories or user home
     if [[ -d "$TARGET_DIR" && "$TARGET_DIR" != "$HOME" && "$TARGET_DIR" != "/" && "$TARGET_DIR" == *"PrismLauncher"* ]]; then


### PR DESCRIPTION
Hey all, thanks for creating this project!

it looks like the link to pollymc that was in here broke: https://github.com/fn2006/PollyMC/releases/latest/download/PollyMC-Linux-x86_64.AppImage

I updated the code here to use the github api to pull the latest version, or you can just hardcode it as https://github.com/PolyMC/PolyMC/releases/download/7.0/PolyMC-Linux-7.0-x86_64.AppImage to lock the version. 

Best!

Asa