### PR TITLE
Fix "Exec format error" for PrismLauncher AppImage

### DIFF
--- a/install-minecraft-splitscreen.sh
+++ b/install-minecraft-splitscreen.sh
@@ -190,7 +190,7 @@ source "$MODULES_DIR/main_workflow.sh"
 
 # Script configuration paths
 readonly TARGET_DIR="$HOME/.local/share/PrismLauncher"
-readonly POLLYMC_DIR="$HOME/.local/share/PollyMC"
+readonly POLLYMC_DIR="$HOME/.local/share/PolyMC"
 
 # Runtime variables (set during execution)
 JAVA_PATH=""

--- a/modules/launcher_setup.sh
+++ b/modules/launcher_setup.sh
@@ -22,7 +22,7 @@ download_prism_launcher() {
     # We specifically look for AppImage files in the release assets
     local prism_url
     prism_url=$(curl -s https://api.github.com/repos/PrismLauncher/PrismLauncher/releases/latest | \
-        jq -r '.assets[] | select(.name | test("AppImage$")) | .browser_download_url' | head -n1)
+        jq -r '.assets[] | select(.name | test("x86_64.*AppImage$")) | .browser_download_url' | head -n1)
     
     # Validate that we got a valid download URL
     if [[ -z "$prism_url" || "$prism_url" == "null" ]]; then


### PR DESCRIPTION
Fixes the following error:
```
⚠  PrismLauncher execution failed, using manual instance creation
💡 Error output: /tmp/minecraft-modules-7vl7wd/launcher_setup.sh: line 53: /home/deck/.local/share/PrismLauncher/PrismLauncher.AppImage: cannot execute binary file: Exec format error
```

The previous query "AppImage$" matched to rows:
*aarch64.AppImage and *x86_64.AppImage, head -n1 selects aarch64 which is wrong architecture for steamdeck