### PR TITLE
Use SharathGames1/PollyMC and add dynamic AppImage resolution with robust fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Both launchers are essentially the same program with one key difference:
 This hybrid approach ensures reliable automated installation while providing the optimal splitscreen gaming experience.
 
 ## What gets installed
-- [PollyMC](https://github.com/fn2006/PollyMC) AppImage (primary launcher)
+- [PollyMC](https://github.com/SharathGames1/PollyMC) AppImage (primary launcher)
 - **Minecraft version:** User-selectable (defaults to latest stable release, with 4 separate instances for splitscreen)
 - **Fabric Loader:** Complete dependency chain including LWJGL 3, Minecraft, Intermediary Mappings, and Fabric Loader
 - **Mods included (automatically installed):**
@@ -192,7 +192,7 @@ To update your Minecraft version or mod configuration:
 ## Credits
 - Inspired by [ArnoldSmith86/minecraft-splitscreen](https://github.com/ArnoldSmith86/minecraft-splitscreen) (original concept/script, but this project is mostly a full rewrite).
 - Additional contributions by [FlyingEwok](https://github.com/FlyingEwok) and others.
-- Uses [PollyMC](https://github.com/fn2006/PollyMC) for gameplay and [PrismLauncher](https://github.com/PrismLauncher/PrismLauncher) for instance creation.
+- Uses [PollyMC](https://github.com/SharathGames1/PollyMC) for gameplay and [PrismLauncher](https://github.com/PrismLauncher/PrismLauncher) for instance creation.
 - Steam Deck Java installation script by [FlyingEwok](https://github.com/FlyingEwok/install-jdk-on-steam-deck) - provides seamless Java installation for Steam Deck's read-only filesystem with automatic version detection.
 - Steam Deck controller auto-disable tool by [scawp](https://github.com/scawp/Steam-Deck.Auto-Disable-Steam-Controller) - automatically disables built-in Steam Deck controller when external controllers are connected, essential for proper splitscreen controller counting.
 

--- a/modules/pollymc_setup.sh
+++ b/modules/pollymc_setup.sh
@@ -53,9 +53,30 @@ setup_pollymc() {
     
     # Download PollyMC AppImage from official GitHub releases
     # AppImage format provides universal Linux compatibility without dependencies
-    # PollyMC GitHub releases API endpoint for latest version
-    # We download the x86_64 Linux AppImage which works on most modern Linux systems
-    local pollymc_url="https://github.com/fn2006/PollyMC/releases/latest/download/PollyMC-Linux-x86_64.AppImage"
+    # Resolve the latest x86_64 AppImage dynamically from release metadata because
+    # asset names can change between releases.
+    local pollymc_url=""
+    local pollymc_release_json=""
+    local pollymc_repo="SharathGames1/PollyMC"
+    pollymc_release_json="$(wget -qO- "https://api.github.com/repos/${pollymc_repo}/releases/latest" 2>/dev/null || true)"
+
+    if [[ -n "$pollymc_release_json" ]]; then
+        pollymc_url="$(jq -r '.assets[]? | select((.name | test("AppImage$")) and (.name | test("x86_64|amd64"; "i"))) | .browser_download_url' \
+            <<< "$pollymc_release_json" 2>/dev/null | head -n1 || true)"
+    fi
+
+    # Fallback: choose any AppImage if architecture-specific asset not detected.
+    if [[ -z "$pollymc_url" || "$pollymc_url" == "null" ]]; then
+        pollymc_url="$(jq -r '.assets[]? | select(.name | test("AppImage$")) | .browser_download_url' \
+            <<< "$pollymc_release_json" 2>/dev/null | head -n1 || true)"
+    fi
+
+    # Last-resort fallback to legacy static URL for environments where API access is blocked.
+    if [[ -z "$pollymc_url" || "$pollymc_url" == "null" ]]; then
+        pollymc_url="https://github.com/${pollymc_repo}/releases/latest/download/PollyMC-Linux-x86_64.AppImage"
+        print_warning "Could not resolve PollyMC asset via GitHub API, using legacy static URL fallback"
+    fi
+
     print_progress "Fetching PollyMC from GitHub releases: $(basename "$pollymc_url")..."
     
     # DOWNLOAD WITH FALLBACK HANDLING


### PR DESCRIPTION
### Motivation
- Update the installer to use the maintained `SharathGames1/PollyMC` releases instead of the previous repository and make AppImage acquisition more robust. 
- Avoid hardcoded asset names so the installer reliably finds the correct AppImage across release changes and network conditions.

### Description
- Replace static PollyMC upstream links in `README.md` to point at `SharathGames1/PollyMC`.
- In `modules/pollymc_setup.sh` add dynamic resolution of the latest AppImage by querying the GitHub Releases API and selecting an `AppImage` asset with `x86_64`/`amd64` in its name using `jq`.
- Add fallbacks: pick any AppImage asset if no arch-specific match is found and finally fall back to a legacy static download URL while emitting a warning when API resolution fails.
- Preserve existing behavior on download failure by falling back to PrismLauncher, set `USE_POLLYMC` appropriately, and make the downloaded AppImage executable.

### Testing
- Ran a basic smoke test by invoking the `setup_pollymc` logic in a network-enabled environment which successfully resolved and downloaded an AppImage and set the `USE_POLLYMC` flag. 
- Verified README link updates render correctly and reference the new `SharathGames1/PollyMC` repository. 
- No additional automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d07f209c88833187393ba3a197b5ff)